### PR TITLE
[feature] 채팅방 구독 기능 추가

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -136,7 +136,13 @@ sockjs.on("connection", (conn) => {
           const [key, value] = header.split(":");
           headerMap[key] = value;
         }
-        const destination = headerMap["destination"];
+        let destination = headerMap["destination"];
+        if (destination && destination.startsWith("/chat/")) {
+          const ids = destination.replace("/chat/", "").split("-");
+          if (ids.length === 2) {
+            destination = `/chat/${ids.sort().join("-")}`;
+          }
+        }
         if (!destination) return;
         if (!subscriptions.has(destination)) {
           subscriptions.set(destination, new Set());
@@ -156,7 +162,13 @@ sockjs.on("connection", (conn) => {
           const [key, value] = headers[i].split(":");
           headerMap[key] = value;
         }
-        const destination = headerMap["destination"];
+        let destination = headerMap["destination"];
+        if (destination && destination.startsWith("/chat/")) {
+          const ids = destination.replace("/chat/", "").split("-");
+          if (ids.length === 2) {
+            destination = `/chat/${ids.sort().join("-")}`;
+          }
+        }
         const messageBody = lines
           .slice(bodyStartIndex)
           .join("\n")
@@ -170,7 +182,7 @@ sockjs.on("connection", (conn) => {
             "MESSAGE\n" +
             `destination:${destination}\n` +
             `message-id:${Date.now()}\n` +
-            `subscription:sub-0\n` + // ✅ 추가: 구독 ID와 매칭
+            `subscription:sub-0\n` +
             "content-type:application/json\n\n" +
             JSON.stringify(messageWithSender) +
             "\0";


### PR DESCRIPTION
### #️⃣ Related Issue
> ex) #8

### 📝 Work Detail
### 1. 서버(server.js)
- 1:1 채팅방 경로 정규화
`/chat/{userId}-{targetUserId}` 형식의 destination에서 두 userId를 항상 정렬하여,
두 사용자가 순서에 상관없이 동일한 채팅방으로 메시지를 주고받을 수 있도록 서버 로직을 수정했습니다.
- SUBSCRIBE, SEND 처리 개선
클라이언트가 `/chat/1-2` 또는 `/chat/2-1`로 요청해도 서버가 /chat/1-2로 통일하여 라우팅합니다.

### 2. 클라이언트(ChatRoom.tsx)
- 1:1 채팅방 UI 및 로직 구현
사용자 목록에서 상대방을 클릭하면 해당 userId로 1:1 채팅방이 열리도록 변경했습니다.
- 본인은 사용자 목록에서 제외했습니다.
- 채팅방 구독 시 `연결됨`으로 강조됩니다.
- 상대방 선택 시에만 메시지 입력/전송 가능합니다.
<img width="1418" alt="스크린샷 2025-06-02 14 33 03" src="https://github.com/user-attachments/assets/158fe21a-84d0-4a79-98a4-dfce46722f98" />

### 3. 클라이언트(WebSocket.ts)
- 1:1 채팅방 구독 및 메시지 전송 로직 구현
`targetUserId`를 인자로 받아 `userId, targetUserId` 조합으로 1:1 채팅방 경로를 동적으로 생성합니다.
- 채팅 상대 변경 시 재구독
- 여러 채팅방 지원 구조로 개선

### 💬 Review Requirements

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? <br>
> ex) merge하고 싶어요!
